### PR TITLE
Fix message marker

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func buildTable(rootPkgName string, base, head *CoverProfile) string {
 	}
 
 	// write totals
-	buf.WriteString(fmt.Sprintf("%80s %8s %8s %8s\n",
+	buf.WriteString(fmt.Sprintf("%80s %8s %8s %8s",
 		"total:",
 		coverageDescription(base.Coverage()),
 		coverageDescription(head.Coverage()),
@@ -108,7 +108,7 @@ func createOrUpdateComment(ctx context.Context, title, details string) {
 	}
 
 	// iterate over existing pull request comments - if existing coverage comment found then update
-	body := fmt.Sprintf("%s\n%s\n%s\n\n```\n%s```\n",
+	body := fmt.Sprintf("%s\n%s\n%s\n\n```\n%s\n```\n",
 		coverageReportHeaderMarkdown,
 		"# Golang test coverage difference report",
 		title, details)

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func buildTable(rootPkgName string, base, head *CoverProfile) string {
 }
 
 func createOrUpdateComment(ctx context.Context, title, details string) {
-	const coverageReportHeaderMarkdown = "<!-- info:golang-cover-diff -->\n# Golang test coverage difference report"
+	const coverageReportHeaderMarkdown = "<!-- info:golang-cover-diff -->"
 
 	auth_token := os.Getenv("GITHUB_TOKEN")
 	if auth_token == "" {
@@ -108,8 +108,9 @@ func createOrUpdateComment(ctx context.Context, title, details string) {
 	}
 
 	// iterate over existing pull request comments - if existing coverage comment found then update
-	body := fmt.Sprintf("%s\n%s\n\n```\n%s```\n",
+	body := fmt.Sprintf("%s\n%s\n%s\n\n```\n%s```\n",
 		coverageReportHeaderMarkdown,
+		"# Golang test coverage difference report",
 		title, details)
 
 	for _, c := range comments {

--- a/main_test.go
+++ b/main_test.go
@@ -32,7 +32,7 @@ func TestBuildTable(t *testing.T) {
 		base := &CoverProfile{}
 		head := &CoverProfile{}
 
-		assert.Equal(t, strings.TrimLeft(`
+		assert.Equal(t, strings.Trim(`
 package                                                                            before    after    delta
 -------                                                                           -------  -------  -------
                                                                           total:        -        -      n/a
@@ -57,7 +57,7 @@ package                                                                         
 			Covered: 33,
 		}
 
-		assert.Equal(t, strings.TrimLeft(`
+		assert.Equal(t, strings.Trim(`
 package                                                                            before    after    delta
 -------                                                                           -------  -------  -------
 my/package                                                                         37.50%        -     gone
@@ -97,7 +97,7 @@ my/package                                                                      
 			},
 		}
 
-		assert.Equal(t, strings.TrimLeft(`
+		assert.Equal(t, strings.Trim(`
 package                                                                            before    after    delta
 -------                                                                           -------  -------  -------
 apples                                                                             32.69%   32.69%   +0.00%


### PR DESCRIPTION
I added the concept of a hidden HTML message marker in 7836705 - but got my own idea of the implementation wrong.

The marker should stand on it's own - even if we update any other part of the visible message in the future - which _includes_ the message title of `# Golang test coverage difference report` - which was not the case. This fixes that.

Also - updated `buildTable()` to no longer add trailing line feed - this is now handled by `createOrUpdateComment()` and it's `fmt.Sprintf()`.