### PR TITLE
Switch from `::set-output` control codes to environment file `$GITHUB_OUTPUT`

### DIFF
--- a/cover.example.yml
+++ b/cover.example.yml
@@ -31,7 +31,7 @@ jobs:
           version-file: go.mod
       - name: Generate Golang source hash base
         id: hash-base
-        run: echo "::set-output name=value::${{ hashFiles('**/*.go','!vendor/**') }}"
+        run: echo "value=${{ hashFiles('**/*.go','!vendor/**') }}" >>"$GITHUB_OUTPUT"
       - name: Cache base cover profile
         id: cache-base
         uses: actions/cache@v3
@@ -55,7 +55,7 @@ jobs:
       - name: Generate Golang source hash head
         if: github.event_name == 'pull_request'
         id: hash-head
-        run: echo "::set-output name=value::${{ hashFiles('**/*.go','!vendor/**') }}"
+        run: echo "value=${{ hashFiles('**/*.go','!vendor/**') }}" >>"$GITHUB_OUTPUT"
       - name: Cache head cover profile
         if: |
           github.event_name == 'pull_request' &&
@@ -85,7 +85,7 @@ jobs:
             --silent \
               https://api.github.com/repos/flipgroup/golang-cover-diff/branches/main | \
                 jq --raw-output ".commit.sha")
-          echo "::set-output name=sha1::$sha1"
+          echo "sha1=$sha1" >>"$GITHUB_OUTPUT"
       - name: Cache golang-cover-diff
         id: cache-golang-cover-diff
         uses: actions/cache@v3


### PR DESCRIPTION
A change to how GitHub actions handle `set-state` / `set-output` commands is now available - deprecating the old method.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Updating the example workflow to reflect this change.