### PR TITLE
Update cover profile cache keys in `cover.example.yml` workflow

### DIFF
--- a/cover.example.yml
+++ b/cover.example.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: cover-${{ steps.hash-base.outputs.value }}.profile
-          key: cover-profile-${{ steps.hash-base.outputs.value }}
+          key: golang-cover-profile-${{ steps.hash-base.outputs.value }}
       - name: Generate base cover profile
         if: steps.cache-base.outputs.cache-hit != 'true'
 
@@ -64,7 +64,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: cover-${{ steps.hash-head.outputs.value }}.profile
-          key: cover-profile-${{ steps.hash-head.outputs.value }}
+          key: golang-cover-profile-${{ steps.hash-head.outputs.value }}
       - name: Generate head cover profile
         if: |
           github.event_name == 'pull_request' &&


### PR DESCRIPTION
Reviewing some GitHub Actions cache keys for a project in the [new GitHub Actions cache management UI](https://github.blog/changelog/2022-10-20-manage-caches-in-your-actions-workflows-from-web-interface/) - and felt that these cover profile caches could use a better key name.