### PR TITLE
Remove version identifier from `Accept:` HTTP header in GitHub API call

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 2m
+  timeout: 5m
 
 linters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,3 +26,8 @@ linters-settings:
     rewrite-rules:
       - pattern: interface{}
         replacement: any
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+      - shadow

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 FLIP Group
+Copyright (c) 2021 Flip Group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cover.example.yml
+++ b/cover.example.yml
@@ -81,7 +81,7 @@ jobs:
         id: golang-cover-diff-main
         run: |
           sha1=$(curl \
-            --header "Accept: application/vnd.github.v3+json" \
+            --header "Accept: application/vnd.github+json" \
             --silent \
               https://api.github.com/repos/flipgroup/golang-cover-diff/branches/main | \
                 jq --raw-output ".commit.sha")


### PR DESCRIPTION
No longer recommended as GitHub moves to [date based REST API versioning](https://github.blog/2022-11-28-to-infinity-and-beyond-enabling-the-future-of-githubs-rest-api-with-api-versioning/).

With this change, we're just going to use GitHub's latest API version in all instances.
