### PR TITLE
Remove `-cover` flag from `go test` lines in `cover.example.yml`

### DIFF
--- a/cover.example.yml
+++ b/cover.example.yml
@@ -44,7 +44,7 @@ jobs:
         # generate base cover profile
         # example:
         # > env:
-        # >   GOFLAGS: -cover -coverprofile=cover-${{ steps.hash-base.outputs.value }}.profile
+        # >   GOFLAGS: -coverprofile=cover-${{ steps.hash-base.outputs.value }}.profile
         # > run: make test
 
       - name: Checkout source
@@ -74,7 +74,7 @@ jobs:
         # generate head cover profile
         # example:
         # > env:
-        # >   GOFLAGS: -cover -coverprofile=cover-${{ steps.hash-head.outputs.value }}.profile
+        # >   GOFLAGS: -coverprofile=cover-${{ steps.hash-head.outputs.value }}.profile
         # > run: make test
 
       - name: Fetch golang-cover-diff @main SHA-1


### PR DESCRIPTION
As per https://go.dev/blog/cover

> (The -coverprofile flag automatically sets -cover to enable coverage analysis.) The test runs just as before, but the results are saved in a file.

Thus we can safely remove this argument to be a little more concise in our workflows.