### PR TITLE
Remove zero delta package line values (e.g. `+0.00%`) - make eye scanning easier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/google/go-github/v45 v45.2.0
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.2
 	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558
 )
 

--- a/go.sum
+++ b/go.sum
@@ -121,10 +121,12 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 	createOrUpdateComment(
 		ctx,
 		summaryMessage(base.Coverage(), head.Coverage()),
-		buildTable(getModuleName(), base, head))
+		buildTable(moduleName(), base, head))
 }
 
 func buildTable(rootPkgName string, base, head *CoverProfile) string {
@@ -44,7 +44,7 @@ func buildTable(rootPkgName string, base, head *CoverProfile) string {
 	buf.WriteString(fmt.Sprintf(tableRowSprintf, "-------", "-------", "-------", "-------"))
 
 	// write package lines
-	for _, pkgName := range getAllPackages(base, head) {
+	for _, pkgName := range allPackages(base, head) {
 		baseCov := base.Packages[pkgName].Coverage()
 		headCov := head.Packages[pkgName].Coverage()
 		buf.WriteString(fmt.Sprintf(tableRowSprintf,
@@ -189,7 +189,7 @@ func summaryMessage(base, head int) string {
 	return fmt.Sprintf("Coverage increased by `%.2f%%`. :medal_sports: Keep it up :medal_sports:", float64(head-base)/100)
 }
 
-func getModuleName() string {
+func moduleName() string {
 	f, err := os.ReadFile("go.mod")
 	if err != nil {
 		// unable to determine package name
@@ -201,7 +201,7 @@ func getModuleName() string {
 	return string(modRegex.FindSubmatch(f)[1])
 }
 
-func getAllPackages(profiles ...*CoverProfile) []string {
+func allPackages(profiles ...*CoverProfile) []string {
 	set := map[string]struct{}{}
 	for _, profile := range profiles {
 		for name := range profile.Packages {

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 	createOrUpdateComment(
 		ctx,
 		summaryMessage(base.Coverage(), head.Coverage()),
-		buildTable(getModulePackageName(), base, head))
+		buildTable(getModuleName(), base, head))
 }
 
 func buildTable(rootPkgName string, base, head *CoverProfile) string {
@@ -186,14 +186,14 @@ func summaryMessage(base, head int) string {
 	return fmt.Sprintf("Coverage increased by `%.2f%%`. :medal_sports: Keep it up :medal_sports:", float64(head-base)/100)
 }
 
-func getModulePackageName() string {
+func getModuleName() string {
 	f, err := os.ReadFile("go.mod")
 	if err != nil {
 		// unable to determine package name
 		return ""
 	}
 
-	// found it, stop searching
+	// opened file - locate `module` line to extract full package name
 	modRegex := regexp.MustCompile(`module +([^\s]+)`)
 	return string(modRegex.FindSubmatch(f)[1])
 }

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func buildTable(rootPkgName string, base, head *CoverProfile) string {
 			relativePackage(rootPkgName, pkgName),
 			coverageDescription(baseCov),
 			coverageDescription(headCov),
-			diffDescription(baseCov, headCov)))
+			diffDescription(baseCov, headCov, true)))
 	}
 
 	// write totals
@@ -59,7 +59,7 @@ func buildTable(rootPkgName string, base, head *CoverProfile) string {
 		"total:",
 		coverageDescription(base.Coverage()),
 		coverageDescription(head.Coverage()),
-		diffDescription(base.Coverage(), head.Coverage()),
+		diffDescription(base.Coverage(), head.Coverage(), false),
 	))
 
 	return buf.String()
@@ -70,7 +70,7 @@ func createOrUpdateComment(ctx context.Context, title, details string) {
 
 	auth_token := os.Getenv("GITHUB_TOKEN")
 	if auth_token == "" {
-		fmt.Println("no GITHUB_TOKEN, unable to report back to GitHub pull request.")
+		fmt.Println("no GITHUB_TOKEN, not reporting to GitHub.")
 		return
 	}
 
@@ -160,7 +160,7 @@ func coverageDescription(coverage int) string {
 	return fmt.Sprintf("%6.2f%%", float64(coverage)/100)
 }
 
-func diffDescription(base, head int) string {
+func diffDescription(base, head int, emptyNoDiff bool) string {
 	if base < 0 && head < 0 {
 		return "n/a"
 	}
@@ -169,6 +169,9 @@ func diffDescription(base, head int) string {
 	}
 	if head < 0 {
 		return "gone"
+	}
+	if base == head && emptyNoDiff {
+		return ""
 	}
 
 	return fmt.Sprintf("%+6.2f%%", float64(head-base)/100)

--- a/main_test.go
+++ b/main_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestModulePackageName(t *testing.T) {
-	assert.Equal(t, "github.com/flipgroup/golang-cover-diff", getModulePackageName())
+func TestModuleName(t *testing.T) {
+	assert.Equal(t, "github.com/flipgroup/golang-cover-diff", getModuleName())
 }
 
 func TestRelativePackage(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestModuleName(t *testing.T) {
-	assert.Equal(t, "github.com/flipgroup/golang-cover-diff", getModuleName())
+	assert.Equal(t, "github.com/flipgroup/golang-cover-diff", moduleName())
 }
 
 func TestRelativePackage(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -97,13 +97,14 @@ my/package                                                                      
 			},
 		}
 
-		assert.Equal(t, strings.Trim(`
+		// note: using `$-$` marker to defeat removal of trailing space from `.editorconfig` settings
+		assert.Equal(t, strings.ReplaceAll(strings.Trim(`
 package                                                                            before    after    delta
 -------                                                                           -------  -------  -------
-apples                                                                             32.69%   32.69%   +0.00%
+apples                                                                             32.69%   32.69%      $-$
 my/package                                                                         37.50%   57.14%  +19.64%
                                                                           total:   33.33%   41.25%   +7.92%
-`, "\n"),
+`, "\n"), "$-$", "   "),
 			buildTable("github.com/flipgroup/golang-cover-diff", base, head))
 	})
 }

--- a/report_test.go
+++ b/report_test.go
@@ -128,14 +128,17 @@ func TestMessaging(t *testing.T) {
 	})
 
 	t.Run("diffDescription()", func(t *testing.T) {
-		assert.Equal(t, "n/a", diffDescription(-1, -1))
-		assert.Equal(t, "new", diffDescription(-1, 100))
-		assert.Equal(t, "gone", diffDescription(100, -1))
+		assert.Equal(t, "n/a", diffDescription(-1, -1, false))
+		assert.Equal(t, "new", diffDescription(-1, 100, false))
+		assert.Equal(t, "gone", diffDescription(100, -1, false))
 
-		assert.Equal(t, " +0.05%", diffDescription(100, 105))
-		assert.Equal(t, " -0.05%", diffDescription(105, 100))
-		assert.Equal(t, " +1.05%", diffDescription(100, 205))
-		assert.Equal(t, " -1.05%", diffDescription(205, 100))
+		assert.Equal(t, " +0.05%", diffDescription(100, 105, false))
+		assert.Equal(t, " -0.05%", diffDescription(105, 100, false))
+		assert.Equal(t, " +1.05%", diffDescription(100, 205, false))
+		assert.Equal(t, " -1.05%", diffDescription(205, 100, false))
+
+		assert.Equal(t, " +0.00%", diffDescription(100, 100, false))
+		assert.Equal(t, "", diffDescription(100, 100, true))
 	})
 
 	t.Run("summaryMessage()", func(t *testing.T) {


### PR DESCRIPTION
This change removes any package line where the delta is no change. This means where a pull request results in minimal coverage change - a user won't be lost in a sea of `+0.00%` values trying to locate the actual packages with change.

Example:

![Screen Shot 2023-03-30 at 14 07 40](https://user-images.githubusercontent.com/1818757/228718385-afb74bf1-2eee-484b-a530-8cea4bc25260.png)

It's hard to see the `+0.28%` change in a sea of `+0.00%`'s.

After the change:

![Screen Shot 2023-03-30 at 14 46 31](https://user-images.githubusercontent.com/1818757/228723674-cc3f3bc7-1402-4430-9f24-e741fc3b45e5.png)


