### PR TITLE
Generate markdown to make detailed report table collapse

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 		buildTable(moduleName(), base, head))
 }
 
-func createOrUpdateComment(ctx context.Context, summary, details string) {
+func createOrUpdateComment(ctx context.Context, summary, reportTable string) {
 	const commentMarker = "<!-- info:golang-cover-diff -->"
 
 	auth_token := os.Getenv("GITHUB_TOKEN")
@@ -77,11 +77,7 @@ func createOrUpdateComment(ctx context.Context, summary, details string) {
 	}
 
 	// iterate over existing pull request comments - if existing coverage comment found then update
-	body := fmt.Sprintf("%s\n%s\n%s\n\n```\n%s\n```\n",
-		commentMarker,
-		"# Golang test coverage difference report",
-		summary, details)
-
+	body := buildCommentBody(commentMarker, summary, reportTable)
 	for _, c := range comments {
 		if c.Body == nil {
 			continue
@@ -111,6 +107,18 @@ func createOrUpdateComment(ctx context.Context, summary, details string) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func buildCommentBody(commentMarker, summary, reportTable string) string {
+	return fmt.Sprintf(
+		("%s\n" +
+			"# Golang test coverage difference report\n" +
+			"%s\n\n" +
+			"<details>\n<summary>Package report</summary>\n\n" +
+			"```\n%s\n```\n" +
+			"</details>"),
+		commentMarker,
+		summary, reportTable)
 }
 
 func buildTable(rootPkgName string, base, head *CoverProfile) string {

--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func createOrUpdateComment(ctx context.Context, title, details string) {
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: auth_token},
 	)
-	tc := oauth2.NewClient(context.Background(), ts)
+	tc := oauth2.NewClient(ctx, ts)
 
 	client := github.NewClient(tc)
 	comments, _, err := client.Issues.ListComments(ctx, owner, repo, prNum, &github.IssueListCommentsOptions{})

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func buildTable(rootPkgName string, base, head *CoverProfile) string {
 	return buf.String()
 }
 
-func createOrUpdateComment(ctx context.Context, title, details string) {
+func createOrUpdateComment(ctx context.Context, summary, details string) {
 	const commentMarker = "<!-- info:golang-cover-diff -->"
 
 	auth_token := os.Getenv("GITHUB_TOKEN")
@@ -111,7 +111,7 @@ func createOrUpdateComment(ctx context.Context, title, details string) {
 	body := fmt.Sprintf("%s\n%s\n%s\n\n```\n%s\n```\n",
 		commentMarker,
 		"# Golang test coverage difference report",
-		title, details)
+		summary, details)
 
 	for _, c := range comments {
 		if c.Body == nil {

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestBuildCommentBody(t *testing.T) {
+	assert.Equal(t,
+		"MARKER\n"+
+			"# Golang test coverage difference report\n"+
+			"Summary\n\n"+
+			"<details>\n<summary>Package report</summary>\n\n"+
+			"```\nReport table\n```\n"+
+			"</details>",
+		buildCommentBody("MARKER", "Summary", "Report table"))
+}
+
 func TestBuildTable(t *testing.T) {
 	t.Run("empty data set", func(t *testing.T) {
 		base := &CoverProfile{}

--- a/main_test.go
+++ b/main_test.go
@@ -7,26 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestModuleName(t *testing.T) {
-	assert.Equal(t, "github.com/flipgroup/golang-cover-diff", moduleName())
-}
-
-func TestRelativePackage(t *testing.T) {
-	const rootPkgName = "github.com/flipgroup/golang-cover-diff/"
-
-	assert.Equal(t,
-		"my/cool/package",
-		relativePackage(rootPkgName, "my/cool/package"))
-
-	assert.Equal(t,
-		"my/cool/package",
-		relativePackage(rootPkgName, "github.com/flipgroup/golang-cover-diff/my/cool/package"))
-
-	assert.Equal(t,
-		"my/cool/package/with/a/stupidly/log/package/path/name/keep/going/on/going/plus/s",
-		relativePackage(rootPkgName, "github.com/flipgroup/golang-cover-diff/my/cool/package/with/a/stupidly/log/package/path/name/keep/going/on/going/plus/some/more/oh/my/when/will/this/end"))
-}
-
 func TestBuildTable(t *testing.T) {
 	t.Run("empty data set", func(t *testing.T) {
 		base := &CoverProfile{}
@@ -107,4 +87,24 @@ my/package                                                                      
 `, "\n"), "$-$", "   "),
 			buildTable("github.com/flipgroup/golang-cover-diff", base, head))
 	})
+}
+
+func TestRelativePackage(t *testing.T) {
+	const rootPkgName = "github.com/flipgroup/golang-cover-diff/"
+
+	assert.Equal(t,
+		"my/cool/package",
+		relativePackage(rootPkgName, "my/cool/package"))
+
+	assert.Equal(t,
+		"my/cool/package",
+		relativePackage(rootPkgName, "github.com/flipgroup/golang-cover-diff/my/cool/package"))
+
+	assert.Equal(t,
+		"my/cool/package/with/a/stupidly/log/package/path/name/keep/going/on/going/plus/s",
+		relativePackage(rootPkgName, "github.com/flipgroup/golang-cover-diff/my/cool/package/with/a/stupidly/log/package/path/name/keep/going/on/going/plus/some/more/oh/my/when/will/this/end"))
+}
+
+func TestModuleName(t *testing.T) {
+	assert.Equal(t, "github.com/flipgroup/golang-cover-diff", moduleName())
 }

--- a/report.go
+++ b/report.go
@@ -100,7 +100,7 @@ func parseCoverProfile(r io.Reader) (*CoverProfile, error) {
 			return nil, fmt.Errorf("malformed coverage line: %s", scanner.Text())
 		}
 
-		// note: format of each coverage line https://github.com/golang/tools/blob/0cf4e2708ac840da8674eb3947b660a931bd2c1f/cover/profile.go#L51-L54
+		// note: format of each coverage line https://github.com/golang/tools/blob/e8f417a962ed6ed4ce93226507cc6e6d007c386b/cover/profile.go#L55-L58
 		path := match[1]
 		pkgName := filepath.Dir(path)
 		fileName := filepath.Base(path)


### PR DESCRIPTION
Change puts the detailed report table into a collapsed markdown section, if someone wishes to review the detailed report - they can click open that section.

Also:

- Fixed a missing `context.Context` that was not threaded.
- Shuffled the ordering of functions to match usage (same with tests) - easier to follow along.
