### PR TITLE
Added `Coverage unchanged.` emoji

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,7 +187,7 @@ func diffDescription(base, head int, emptyNoDiff bool) string {
 
 func summaryMessage(base, head int) string {
 	if base == head {
-		return "Coverage unchanged."
+		return "Coverage unchanged. :2nd_place_medal:"
 	}
 
 	if base > head {

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func createOrUpdateComment(ctx context.Context, summary, reportTable string) {
 func buildCommentBody(commentMarker, summary, reportTable string) string {
 	return fmt.Sprintf(
 		("%s\n" +
-			"# Golang test coverage difference report\n" +
+			"# Golang test coverage difference report\n\n" +
 			"%s\n\n" +
 			"<details>\n<summary>Package report</summary>\n\n" +
 			"```\n%s\n```\n" +

--- a/main_test.go
+++ b/main_test.go
@@ -10,7 +10,7 @@ import (
 func TestBuildCommentBody(t *testing.T) {
 	assert.Equal(t,
 		"MARKER\n"+
-			"# Golang test coverage difference report\n"+
+			"# Golang test coverage difference report\n\n"+
 			"Summary\n\n"+
 			"<details>\n<summary>Package report</summary>\n\n"+
 			"```\nReport table\n```\n"+

--- a/report_test.go
+++ b/report_test.go
@@ -142,7 +142,7 @@ func TestMessaging(t *testing.T) {
 	})
 
 	t.Run("summaryMessage()", func(t *testing.T) {
-		assert.Equal(t, "Coverage unchanged.", summaryMessage(100, 100))
+		assert.Equal(t, "Coverage unchanged. :2nd_place_medal:", summaryMessage(100, 100))
 		assert.Equal(t, "Coverage decreased by `1.05%`. :bell: Shame :bell:", summaryMessage(205, 100))                         // 2.05% -> 1.00%
 		assert.Equal(t, "Coverage decreased by `99.00%`. :bell: Shame :bell:", summaryMessage(10000, 100))                      // 100.00% -> 1.00%
 		assert.Equal(t, "Coverage decreased by `98.98%`. :bell: Shame :bell:", summaryMessage(10000, 102))                      // 100.00% -> 1.02%


### PR DESCRIPTION
Just something to make it a little more obvious that you've maintained the same coverage levels. 👍

![Screen Shot 2023-05-04 at 11 32 50](https://user-images.githubusercontent.com/1818757/236089690-d795a31e-8020-4741-b1ea-a725d6ba801d.png)
