### PR TITLE
Bump `golangci-lint` version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
         uses: flipgroup/action-golang-with-lint@main
         with:
           version-golang-file: go.mod
-          version-golangci-lint: v1.53.3
+          version-golangci-lint: v1.55.1
       - name: Test
         run: go test -count=1 -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters-settings:
   exhaustive:
     default-signifies-exhaustive: true
   goconst:
+    ignore-tests: true
     min-len: 2
     min-occurrences: 2
   gofmt:
@@ -33,5 +34,3 @@ linters-settings:
     disable:
       - fieldalignment
       - shadow
-  makezero:
-    always: false


### PR DESCRIPTION
- Bump `golangci-lint` to `v1.55.1`, built against Golang `1.21`.
- Remove `makezero` linter default.
