### PR TITLE
GitHub actions bump

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Golang with lint
         uses: flipgroup/action-golang-with-lint@main
         with:

--- a/cover.example.yml
+++ b/cover.example.yml
@@ -34,7 +34,7 @@ jobs:
         run: echo "value=${{ hashFiles('**/*.go','!vendor/**') }}" >>"$GITHUB_OUTPUT"
       - name: Cache base cover profile
         id: cache-base
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: cover-${{ steps.hash-base.outputs.value }}.profile
           key: golang-cover-profile-${{ steps.hash-base.outputs.value }}
@@ -61,7 +61,7 @@ jobs:
           github.event_name == 'pull_request' &&
           steps.hash-base.outputs.value != steps.hash-head.outputs.value
         id: cache-head
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: cover-${{ steps.hash-head.outputs.value }}.profile
           key: golang-cover-profile-${{ steps.hash-head.outputs.value }}
@@ -88,7 +88,7 @@ jobs:
           echo "sha1=$sha1" >>"$GITHUB_OUTPUT"
       - name: Cache golang-cover-diff
         id: cache-golang-cover-diff
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/go/bin/golang-cover-diff
           key: ${{ runner.os }}-golang-cover-diff-sha1-${{ steps.golang-cover-diff-main.outputs.sha1 }}

--- a/cover.example.yml
+++ b/cover.example.yml
@@ -19,10 +19,10 @@ jobs:
 
       - name: Checkout source
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout pull request base
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
       - name: Setup Golang with cache
@@ -49,7 +49,7 @@ jobs:
 
       - name: Checkout source
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           clean: false
       - name: Generate Golang source hash head

--- a/cover.example.yml
+++ b/cover.example.yml
@@ -90,7 +90,7 @@ jobs:
         id: cache-golang-cover-diff
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-golang-cover-diff-sha1-${{ steps.golang-cover-diff-main.outputs.sha1 }}
+          key: golang-cover-diff-${{ runner.os }}-sha1-${{ steps.golang-cover-diff-main.outputs.sha1 }}
           path: ~/go/bin/golang-cover-diff
       - name: Install golang-cover-diff
         if: steps.cache-golang-cover-diff.outputs.cache-hit != 'true'

--- a/cover.example.yml
+++ b/cover.example.yml
@@ -36,8 +36,8 @@ jobs:
         id: cache-base
         uses: actions/cache@v4
         with:
-          path: cover-${{ steps.hash-base.outputs.value }}.profile
           key: golang-cover-profile-${{ steps.hash-base.outputs.value }}
+          path: cover-${{ steps.hash-base.outputs.value }}.profile
       - name: Generate base cover profile
         if: steps.cache-base.outputs.cache-hit != 'true'
 
@@ -63,8 +63,8 @@ jobs:
         id: cache-head
         uses: actions/cache@v4
         with:
-          path: cover-${{ steps.hash-head.outputs.value }}.profile
           key: golang-cover-profile-${{ steps.hash-head.outputs.value }}
+          path: cover-${{ steps.hash-head.outputs.value }}.profile
       - name: Generate head cover profile
         if: |
           github.event_name == 'pull_request' &&
@@ -90,8 +90,8 @@ jobs:
         id: cache-golang-cover-diff
         uses: actions/cache@v4
         with:
-          path: ~/go/bin/golang-cover-diff
           key: ${{ runner.os }}-golang-cover-diff-sha1-${{ steps.golang-cover-diff-main.outputs.sha1 }}
+          path: ~/go/bin/golang-cover-diff
       - name: Install golang-cover-diff
         if: steps.cache-golang-cover-diff.outputs.cache-hit != 'true'
         run: go install github.com/flipgroup/golang-cover-diff@main


### PR DESCRIPTION
Bumping GitHub Action versions to those supporting Node.js v20 - [since v16 is now deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).