### PR TITLE
Drop use of `exportloopref` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ linters:
   enable:
     - errname
     - exhaustive
-    - exportloopref
     - gci
     - goconst
     - godot


### PR DESCRIPTION
Drop use of `exportloopref` linter - no longer needed with Golang `1.22` - each `for {}` loop run gets it's own iteration copy of loop variables. Removing linter for speed and possible false positives.
