### PR TITLE
Bump `golangci-lint` to `v1.61.0`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
         uses: flipgroup/action-golang-with-lint@main
         with:
           version-golang-file: go.mod
-          version-golangci-lint: v1.59.1
+          version-golangci-lint: v1.61.0
       - name: Test
         run: go test -count=1 -v ./...


### PR DESCRIPTION
Bump `golangci-lint` to version `v1.61.0`.

[Release notes](https://github.com/golangci/golangci-lint/releases/tag/v1.61.0)
