### PR TITLE
Bump `golangci-lint` version to `v1.63.4`, add linters: `dupword` and `nolintlint`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
         uses: flipgroup/action-golang-with-lint@main
         with:
           version-golang-file: go.mod
-          version-golangci-lint: v1.62.0
+          version-golangci-lint: v1.63.4
       - name: Test
         run: go test -count=1 -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ run:
 
 linters:
   enable:
+    - dupword
     - errname
     - exhaustive
     - gci
@@ -10,6 +11,7 @@ linters:
     - godot
     - gofmt
     - makezero
+    - nolintlint
     - perfsprint
     - unconvert
     - unparam
@@ -34,5 +36,7 @@ linters-settings:
     disable:
       - fieldalignment
       - shadow
+  nolintlint:
+    require-specific: true
   perfsprint:
     strconcat: false


### PR DESCRIPTION
- Bump `golangci-lint` version to `v1.63.4`
- Addition of two new linters
  - `dupword` detects duplicate words (e.g. stutter).
  - `nolintlint` detects malformed and/or ineffective `//nolint:*` directives.
