### PR TITLE
Update workflow example to only execute workflow if Golang files have changed

### DIFF
--- a/cover.example.yml
+++ b/cover.example.yml
@@ -5,9 +5,15 @@ concurrency:
 
 on:
   pull_request:
+    paths:
+      - '**.go'
+      - '!vendor/**'
   push:
     branches:
       - main
+    paths:
+      - '**.go'
+      - '!vendor/**'
 
 jobs:
   main:


### PR DESCRIPTION
Update example GitHub Actions workflow (`cover.example.yml`) to only run coverage reporter if Golang source files have changed - otherwise, no need to run a coverage report - saving workflow runtime minutes.
