### PR TITLE
Bump Golang `v1.26`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,7 @@
 name: Test
+concurrency:
+  cancel-in-progress: true
+  group: test-${{ github.ref }}
 
 on:
   pull_request:
@@ -17,6 +20,6 @@ jobs:
         uses: flipgroup/action-golang-with-lint@main
         with:
           version-golang-file: go.mod
-          version-golangci-lint: v2.6.2
+          version-golangci-lint: v2.11.4
       - name: Test
         run: go test -count=1 -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,15 +5,8 @@ formatters:
     - gci
     - gofmt
 
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: interface{}
-          replacement: any
-
 linters:
   enable:
-    - copyloopvar
     - dupword
     - errname
     - exhaustive
@@ -21,6 +14,7 @@ linters:
     - goconst
     - godot
     - makezero
+    - modernize
     - nolintlint
     - perfsprint
     - unconvert

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flipgroup/golang-cover-diff
 
-go 1.24.0
+go 1.26
 
 require (
 	github.com/google/go-github/v45 v45.2.0


### PR DESCRIPTION
- Update Golang to `v1.26`.
- Update `golangci-lint` to `v2.11.4`.
- Add `modernize` to `golangci-lint`, remove now unrequired linters.
