### PR TITLE
Update example `actions/*` versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 [![Test](https://github.com/flipgroup/golang-cover-diff/actions/workflows/test.yml/badge.svg)](https://github.com/flipgroup/golang-cover-diff/actions/workflows/test.yml)
 
-This tool - designed for use within a GitHub Actions workflow, will compare `go test` produced cover profiles and report coverage deltas back into a GitHub pull request.
+This tool is designed for use within a GitHub Actions workflow for comparing `go test` produced cover profiles and reporting coverage deltas back into a GitHub pull request as a comment entry.
 
 See [`cover.example.yml`](cover.example.yml) for an example coverage GitHub Actions workflow template.

--- a/cover.example.yml
+++ b/cover.example.yml
@@ -25,10 +25,10 @@ jobs:
 
       - name: Checkout source
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Checkout pull request base
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
       - name: Setup Golang with cache
@@ -40,7 +40,7 @@ jobs:
         run: echo "value=${{ hashFiles('**/*.go','!vendor/**') }}" >>"$GITHUB_OUTPUT"
       - name: Cache base cover profile
         id: cache-base
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: golang-cover-profile-${{ steps.hash-base.outputs.value }}
           path: cover-${{ steps.hash-base.outputs.value }}.profile
@@ -55,7 +55,7 @@ jobs:
 
       - name: Checkout source
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           clean: false
       - name: Generate Golang source hash head
@@ -67,7 +67,7 @@ jobs:
           github.event_name == 'pull_request' &&
           steps.hash-base.outputs.value != steps.hash-head.outputs.value
         id: cache-head
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: golang-cover-profile-${{ steps.hash-head.outputs.value }}
           path: cover-${{ steps.hash-head.outputs.value }}.profile
@@ -94,7 +94,7 @@ jobs:
           echo "sha1=$sha1" >>"$GITHUB_OUTPUT"
       - name: Cache golang-cover-diff
         id: cache-golang-cover-diff
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: golang-cover-diff-${{ runner.os }}-sha1-${{ steps.golang-cover-diff-main.outputs.sha1 }}
           path: ~/go/bin/golang-cover-diff


### PR DESCRIPTION
Bump used `actions/*` major versions referenced in `cover.example.yml`.
