### PR TITLE
GitHub Actions bump Node.js `v24` releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # @v6.0.3
       - name: Setup Golang with lint
         uses: flipgroup/action-golang-with-lint@main
         with:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Flip Group
+Copyright (c) 2026 Flip Group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Applies the following GitHub Action workflow changes:

- Implement the use of GitHub Actions compatible with Node.js `v24`.
- Swap out the use of version tags for external actions to full SHA-1 commits to defeat action tainting / supply chain attacks.
